### PR TITLE
Fix broken transform example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All channels and handlers exist within the context of a message bus. The bus pro
 var bus = require('integration').bus();
 
 bus.channel('lowercase');
-bus.transform(String.prototype.toUpperCase, { input: 'lowercase', output: 'uppercase' });
+bus.transform(function(message){return message.toUpperCase()}, { input: 'lowercase', output: 'uppercase' });
 bus.channel('uppercase');
 bus.outboundAdapter(function (str) {
   console.log(str);


### PR DESCRIPTION
the transform example (which capitalizes an input string) didn't work for me (using `integration-0.3.1` and `node-0.8.17`). i believe this is because the translator, `String.prototype.toUpperCase`, is an instance method, and the translator is [invoked without a `this`-binding](https://github.com/s2js/integration/commit/9068264d57a8cbce2df5cc59ca60471c591699d6#L20R562) - so i just provided an anonymous function that invokes `toUpperCase()` on the payload. maybe it would be interesting to bind translator invocations to the message (or even the bus / routing context), and allow it to access the payload, headers, and other properties/methods via `this`? 
